### PR TITLE
Update ELB ciphers to remove RC4

### DIFF
--- a/configuration/elb-cloudformation.json
+++ b/configuration/elb-cloudformation.json
@@ -45,6 +45,7 @@
           { "Name" : "ECDHE-RSA-AES128-SHA256", "Value" : "true" },
           { "Name" : "ECDHE-ECDSA-AES128-SHA", "Value" : "true" },
           { "Name" : "ECDHE-RSA-AES128-SHA", "Value" : "true" },
+          { "Name" : "DHE-DSS-AES128-SHA", "Value" : "true" },
           { "Name" : "ECDHE-ECDSA-AES256-GCM-SHA384", "Value" : "true" },
           { "Name" : "ECDHE-RSA-AES256-GCM-SHA384", "Value" : "true" },
           { "Name" : "ECDHE-ECDSA-AES256-SHA384", "Value" : "true" },
@@ -58,12 +59,9 @@
           { "Name" : "AES256-SHA256", "Value" : "false" },
           { "Name" : "AES256-SHA", "Value" : "false" },
           { "Name" : "DHE-RSA-AES128-SHA", "Value" : "true" },
-          { "Name" : "DHE-DSS-AES128-SHA", "Value" : "true" },
           { "Name" : "CAMELLIA128-SHA", "Value" : "false" },
           { "Name" : "EDH-RSA-DES-CBC3-SHA", "Value" : "false" },
-          { "Name" : "DES-CBC3-SHA", "Value" : "false" },
-          { "Name" : "ECDHE-RSA-RC4-SHA", "Value" : "true" },
-          { "Name" : "RC4-SHA", "Value" : "true" }
+          { "Name" : "DES-CBC3-SHA", "Value" : "true" }
         ],
         "LoadBalancerPorts" : ["443"]
       }]

--- a/configuration/elb.md
+++ b/configuration/elb.md
@@ -99,6 +99,7 @@ AWS comes with a few "predefined" configurations, but does not allow you to save
 - [X] ECDHE-RSA-AES128-SHA256
 - [X] ECDHE-ECDSA-AES128-SHA
 - [X] ECDHE-RSA-AES128-SHA
+- [X] DHE-RSA-AES128-SHA
 - [X] ECDHE-ECDSA-AES256-GCM-SHA384
 - [X] ECDHE-RSA-AES256-GCM-SHA384
 - [X] ECDHE-ECDSA-AES256-SHA384
@@ -111,12 +112,9 @@ AWS comes with a few "predefined" configurations, but does not allow you to save
 - [ ] AES256-GCM-SHA384
 - [ ] AES256-SHA256
 - [ ] AES256-SHA
-- [X] DHE-RSA-AES128-SHA
 - [X] DHE-DSS-AES128-SHA
 - [ ] CAMELLIA128-SHA
 - [ ] EDH-RSA-DES-CBC3-SHA
-- [ ] DES-CBC3-SHA
-- [X] ECDHE-RSA-RC4-SHA
-- [X] RC4-SHA
+- [X] DES-CBC3-SHA
 
-... everything below this should stay unchecked ...
+... Everything below this should stay unchecked. ...


### PR DESCRIPTION
This abandons RC4, which [is dangerously old and weak](https://community.qualys.com/blogs/securitylabs/2013/03/19/rc4-in-tls-is-broken-now-what), now [formally prohibited by RFC 7465](https://tools.ietf.org/html/rfc7465), and which caps one's SSL Labs score to a B.

It also brings the ciphers to the same set we use in our [nginx config](https://github.com/fisma-ready/nginx/blob/master/ssl/ssl.rules#L31). It seems I missed the ability to use the 3DES cipher the first time around.